### PR TITLE
Log information when chained job starts and finishes

### DIFF
--- a/lib/chained_job.rb
+++ b/lib/chained_job.rb
@@ -14,6 +14,10 @@ module ChainedJob
     config.redis || raise(ConfigurationError, 'Redis is not configured')
   end
 
+  def logger
+    config.logger
+  end
+
   def config
     @config ||= ChainedJob::Config.new
   end

--- a/lib/chained_job/process.rb
+++ b/lib/chained_job/process.rb
@@ -14,13 +14,19 @@ module ChainedJob
     end
 
     def run
-      return unless argument
+      return log_finished_worker unless argument
 
       job_instance.process(argument)
       job_instance.class.perform_later(worker_id)
     end
 
     private
+
+    def log_finished_worker
+      ChainedJob.logger.info(
+        "#{job_instance.class} worker #{worker_id} finished"
+      )
+    end
 
     def argument
       @argument ||= ChainedJob.redis.lpop(redis_key)

--- a/lib/chained_job/start_chains.rb
+++ b/lib/chained_job/start_chains.rb
@@ -21,6 +21,8 @@ module ChainedJob
 
       store_job_arguments
 
+      log_chained_job_start
+
       parallelism.times { |worked_id| job_class.perform_later(worked_id) }
     end
 
@@ -32,6 +34,13 @@ module ChainedJob
       end
 
       redis.expire(redis_key, config.arguments_queue_expiration)
+    end
+
+    def log_chained_job_start
+      ChainedJob.logger.info(
+        "#{job_class} starting #{parallelism} workers "\
+        "processing #{array_of_job_arguments.count} items"
+      )
     end
 
     def redis

--- a/test/chained_job/process_test.rb
+++ b/test/chained_job/process_test.rb
@@ -19,6 +19,7 @@ class ChainedJob::ProcessTest < Minitest::Test
     redis.lpop(redis_key)
 
     job_instance.expect(:class, job_class, [])
+    job_instance.expect(:class, job_class, [])
     tested_class.run(job_instance, 1)
 
     job_instance.verify


### PR DESCRIPTION
Adding logging when workers are being started, with how many arguments in list. Also when worker is finishing job.

<img width="1556" alt="Screenshot 2020-04-22 at 13 36 41" src="https://user-images.githubusercontent.com/45848524/79972323-73293100-849e-11ea-9a19-7b13a85151dd.png">


@vinted/payments-backend @zverseckas 