### PR TITLE
Add hooks

### DIFF
--- a/lib/chained_job/config.rb
+++ b/lib/chained_job/config.rb
@@ -23,8 +23,8 @@ module ChainedJob
 
       self.logger = ::Logger.new(STDOUT)
 
-      self.around_start_chains = ->(_job_class, &block) { block.call }
-      self.around_chain_process = ->(_job_class, &block) { block.call }
+      self.around_start_chains = ->(_options, &block) { block.call }
+      self.around_chain_process = ->(_options, &block) { block.call }
 
       self.debug = true
     end

--- a/lib/chained_job/middleware.rb
+++ b/lib/chained_job/middleware.rb
@@ -7,13 +7,9 @@ module ChainedJob
   module Middleware
     def perform(worker_id = nil)
       if worker_id
-        ChainedJob.config.around_chain_process.call(self.class) do
-          ChainedJob::Process.run(self, worker_id)
-        end
+        ChainedJob::Process.run(self, worker_id)
       else
-        ChainedJob.config.around_start_chains.call(self.class) do
-          ChainedJob::StartChains.run(self.class, array_of_job_arguments, parallelism)
-        end
+        ChainedJob::StartChains.run(self.class, array_of_job_arguments, parallelism)
       end
     end
   end

--- a/lib/chained_job/start_chains.rb
+++ b/lib/chained_job/start_chains.rb
@@ -17,18 +17,32 @@ module ChainedJob
     end
 
     def run
-      redis.del(redis_key)
+      with_hooks do
+        redis.del(redis_key)
 
-      return unless array_of_job_arguments.count.positive?
+        return unless array_of_job_arguments.count.positive?
 
-      store_job_arguments
+        store_job_arguments
 
-      log_chained_job_start
+        log_chained_job_start
 
-      parallelism.times { |worked_id| job_class.perform_later(worked_id) }
+        parallelism.times { |worked_id| job_class.perform_later(worked_id) }
+      end
     end
 
     private
+
+    def with_hooks
+      ChainedJob.config.around_start_chains.call(options) { yield }
+    end
+
+    def options
+      {
+        job_class: job_class,
+        array_of_job_arguments: array_of_job_arguments,
+        parallelism: parallelism,
+      }
+    end
 
     def store_job_arguments
       array_of_job_arguments.each_slice(config.arguments_batch_size) do |sublist|

--- a/test/chained_job/process_test.rb
+++ b/test/chained_job/process_test.rb
@@ -4,10 +4,12 @@ require 'mock_redis'
 require 'minitest/autorun'
 
 class ChainedJob::ProcessTest < Minitest::Test
+  # rubocop:disable Metrics/AbcSize
   def test_process_chain
     job_instance.expect(:class, job_class, [])
-    job_instance.expect(:process, nil, ['1'])
     job_instance.expect(:class, job_class, [])
+    job_instance.expect(:class, job_class, [])
+    job_instance.expect(:process, nil, ['1'])
     job_class.expect(:perform_later, nil, [1])
 
     tested_class.run(job_instance, 1)
@@ -20,10 +22,12 @@ class ChainedJob::ProcessTest < Minitest::Test
 
     job_instance.expect(:class, job_class, [])
     job_instance.expect(:class, job_class, [])
+    job_instance.expect(:class, job_class, [])
     tested_class.run(job_instance, 1)
 
     job_instance.verify
   end
+  # rubocop:enable Metrics/AbcSize
 
   private
 


### PR DESCRIPTION
Right now in svc-payments we have time monitoring for `process` method and `array_of_job_arguments`.

I want to setup two hooks to conditionally do something while these interactors are beinging executed.
We could monitor how long does it take to start chains and to process one job.

From client side we could setup monitoring which we want something like this:
```
config.around_chain_process = ->(job_name, &block) do
  time = Benchmark.ms { block.call }

   puts time
end
``` 
Not sure if I did setup around hook correct thou.. 😄 

@vinted/payments-backend 