### PR TITLE
Raise error for undefined client methods

### DIFF
--- a/lib/chained_job/middleware.rb
+++ b/lib/chained_job/middleware.rb
@@ -12,5 +12,13 @@ module ChainedJob
         ChainedJob::StartChains.run(self.class, array_of_job_arguments, parallelism)
       end
     end
+
+    def array_of_job_arguments
+      raise NoMethodError, 'undefined method array_of_job_arguments'
+    end
+
+    def parallelism
+      raise NoMethodError, 'undefined method parallelism'
+    end
   end
 end


### PR DESCRIPTION
Error would be raised if one of the methods are not created in client side.
Chose `NoMethodError` vs `NotImplementedError` since `NoMethodError` is under `StandardError` so `rescue => e` would work in this place.

@vinted/payments-backend 