### PR TITLE
Use next to escape from block

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    chained_job (0.1.1)
+    chained_job (0.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/chained_job/start_chains.rb
+++ b/lib/chained_job/start_chains.rb
@@ -20,7 +20,7 @@ module ChainedJob
       with_hooks do
         redis.del(redis_key)
 
-        return unless array_of_job_arguments.count.positive?
+        next unless array_of_job_arguments.count.positive?
 
         store_job_arguments
 

--- a/lib/chained_job/version.rb
+++ b/lib/chained_job/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ChainedJob
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end


### PR DESCRIPTION
Problem:

When job does not have arguments we return fast and do not start chains. With return around hooks is not being finished
> return has no special meaning in blocks, but it can be misunderstood as "return from block", which is wrong

Using `next` should help 
https://github.com/vinted/chained_job/issues/22

@vinted/payments-backend 