### PR TITLE
Add support for overlapping chained jobs

### DIFF
--- a/lib/chained_job/clean_up_queue.rb
+++ b/lib/chained_job/clean_up_queue.rb
@@ -18,14 +18,15 @@ module ChainedJob
 
     def run
       loop do
-        tag = redis.spop(tag_list)
+        tag = ChainedJob.redis.spop(tag_list)
 
         break unless tag
 
         redis_key = Helpers.redis_key(job_key, tag)
-        size = redis.llen(redis_key)
-        (size / TRIM_STEP_SIZE).times { redis.ltrim(redis_key, 0, -TRIM_STEP_SIZE) }
-        redis.del(redis_key)
+        size = ChainedJob.redis.llen(redis_key)
+        (size / TRIM_STEP_SIZE).times { ChainedJob.redis.ltrim(redis_key, 0, -TRIM_STEP_SIZE) }
+
+        ChainedJob.redis.del(redis_key)
       end
     end
 
@@ -37,10 +38,6 @@ module ChainedJob
 
     def job_key
       @job_key ||= Helpers.job_key(job_class)
-    end
-
-    def redis
-      ChainedJob.redis
     end
   end
 end

--- a/lib/chained_job/clean_up_queue.rb
+++ b/lib/chained_job/clean_up_queue.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'chained_job/helpers'
+
+module ChainedJob
+  class CleanUpQueue
+    def self.run(job_class)
+      new(job_class).run
+    end
+
+    TRIM_STEP_SIZE = 1_000
+
+    attr_reader :job_class
+
+    def initialize(job_class)
+      @job_class = job_class
+    end
+
+    def run
+      loop do
+        tag = redis.spop(tag_list)
+
+        break unless tag
+
+        size = redis.llen(redis_key(tag))
+        (size / TRIM_STEP_SIZE).times { redis.ltrim(redis_key(tag), 0, -TRIM_STEP_SIZE) }
+        redis.del(redis_key(tag))
+      end
+    end
+
+    private
+
+    def tag_list
+      @tag_list ||= Helpers.tag_list(job_key)
+    end
+
+    def redis_key(tag)
+      @redis_key ||= Helpers.redis_key(job_key, tag)
+    end
+
+    def job_key
+      @job_key ||= Helpers.job_key(job_class)
+    end
+
+    def redis
+      ChainedJob.redis
+    end
+  end
+end

--- a/lib/chained_job/clean_up_queue.rb
+++ b/lib/chained_job/clean_up_queue.rb
@@ -16,6 +16,7 @@ module ChainedJob
       @job_class = job_class
     end
 
+    # rubocop:disable Metrics/AbcSize
     def run
       loop do
         tag = ChainedJob.redis.spop(tag_list)
@@ -29,6 +30,7 @@ module ChainedJob
         ChainedJob.redis.del(redis_key)
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     private
 

--- a/lib/chained_job/clean_up_queue.rb
+++ b/lib/chained_job/clean_up_queue.rb
@@ -22,9 +22,10 @@ module ChainedJob
 
         break unless tag
 
-        size = redis.llen(redis_key(tag))
-        (size / TRIM_STEP_SIZE).times { redis.ltrim(redis_key(tag), 0, -TRIM_STEP_SIZE) }
-        redis.del(redis_key(tag))
+        redis_key = Helpers.redis_key(job_key, tag)
+        size = redis.llen(redis_key)
+        (size / TRIM_STEP_SIZE).times { redis.ltrim(redis_key, 0, -TRIM_STEP_SIZE) }
+        redis.del(redis_key)
       end
     end
 
@@ -32,10 +33,6 @@ module ChainedJob
 
     def tag_list
       @tag_list ||= Helpers.tag_list(job_key)
-    end
-
-    def redis_key(tag)
-      @redis_key ||= Helpers.redis_key(job_key, tag)
     end
 
     def job_key

--- a/lib/chained_job/helpers.rb
+++ b/lib/chained_job/helpers.rb
@@ -9,7 +9,7 @@ module ChainedJob
     end
 
     def redis_key(key, tag)
-      "#{key}:#{tag}"
+      "chained_job:#{key}:#{tag}"
     end
 
     def tag_list(prefix)

--- a/lib/chained_job/helpers.rb
+++ b/lib/chained_job/helpers.rb
@@ -12,8 +12,8 @@ module ChainedJob
       "chained_job:#{key}:#{tag}"
     end
 
-    def tag_list(prefix)
-      "#{prefix}:tags"
+    def tag_list(job_class)
+      "#{job_class}:tags"
     end
   end
 end

--- a/lib/chained_job/helpers.rb
+++ b/lib/chained_job/helpers.rb
@@ -12,8 +12,8 @@ module ChainedJob
       "chained_job:#{key}:#{tag}"
     end
 
-    def tag_list(job_class)
-      "#{job_class}:tags"
+    def tag_list(prefix)
+      "#{prefix}:tags"
     end
   end
 end

--- a/lib/chained_job/helpers.rb
+++ b/lib/chained_job/helpers.rb
@@ -8,8 +8,8 @@ module ChainedJob
       "chained_job:#{job_class}"
     end
 
-    def redis_key(key, tag)
-      "chained_job:#{key}:#{tag}"
+    def redis_key(job_key, tag)
+      "#{job_key}:#{tag}"
     end
 
     def tag_list(prefix)

--- a/lib/chained_job/helpers.rb
+++ b/lib/chained_job/helpers.rb
@@ -4,8 +4,16 @@ module ChainedJob
   module Helpers
     module_function
 
-    def redis_key(job_class)
+    def job_key(job_class)
       "chained_job:#{job_class}"
+    end
+
+    def redis_key(key, tag)
+      "#{key}:#{tag}"
+    end
+
+    def tag_list(prefix)
+      "#{prefix}:tags"
     end
   end
 end

--- a/lib/chained_job/middleware.rb
+++ b/lib/chained_job/middleware.rb
@@ -9,9 +9,9 @@ module ChainedJob
       base.queue_as ChainedJob.config.queue if ChainedJob.config.queue
     end
 
-    def perform(worker_id = nil)
+    def perform(worker_id = nil, tag = nil)
       if worker_id
-        ChainedJob::Process.run(self, worker_id)
+        ChainedJob::Process.run(self, worker_id, tag)
       else
         ChainedJob::StartChains.run(self.class, array_of_job_arguments, parallelism)
       end

--- a/lib/chained_job/process.rb
+++ b/lib/chained_job/process.rb
@@ -45,7 +45,7 @@ module ChainedJob
     end
 
     def redis_key
-      Helpers.redis_key(job_instance.class)
+      Helpers.redis_key(job_instance.class, job_tag)
     end
   end
 end

--- a/lib/chained_job/process.rb
+++ b/lib/chained_job/process.rb
@@ -36,7 +36,7 @@ module ChainedJob
 
     def log_finished_worker
       ChainedJob.logger.info(
-        "#{job_instance.class} worker #{worker_id} finished"
+        "#{job_instance.class}:#{job_tag} worker #{worker_id} finished"
       )
     end
 

--- a/lib/chained_job/process.rb
+++ b/lib/chained_job/process.rb
@@ -13,6 +13,7 @@ module ChainedJob
     def initialize(job_instance, worker_id, job_tag)
       @job_instance = job_instance
       @worker_id = worker_id
+      @job_tag = job_tag
     end
 
     def run
@@ -45,7 +46,11 @@ module ChainedJob
     end
 
     def redis_key
-      Helpers.redis_key(job_instance.class, job_tag)
+      Helpers.redis_key(job_key, job_tag)
+    end
+
+    def job_key
+      Helpers.job_key(job_instance.class)
     end
   end
 end

--- a/lib/chained_job/process.rb
+++ b/lib/chained_job/process.rb
@@ -4,13 +4,13 @@ require 'chained_job/helpers'
 
 module ChainedJob
   class Process
-    def self.run(job_instance, worker_id)
-      new(job_instance, worker_id).run
+    def self.run(job_instance, worker_id, job_tag)
+      new(job_instance, worker_id, job_tag).run
     end
 
-    attr_reader :job_instance, :worker_id
+    attr_reader :job_instance, :worker_id, :job_tag
 
-    def initialize(job_instance, worker_id)
+    def initialize(job_instance, worker_id, job_tag)
       @job_instance = job_instance
       @worker_id = worker_id
     end
@@ -20,7 +20,7 @@ module ChainedJob
         return log_finished_worker unless argument
 
         job_instance.process(argument)
-        job_instance.class.perform_later(worker_id)
+        job_instance.class.perform_later(worker_id, job_tag)
       end
     end
 

--- a/lib/chained_job/start_chains.rb
+++ b/lib/chained_job/start_chains.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'chained_job/helpers'
+require 'chained_job/clean_up_queue'
+require 'chained_job/store_job_arguments'
 
 module ChainedJob
   class StartChains
@@ -18,15 +20,15 @@ module ChainedJob
 
     def run
       with_hooks do
-        redis.del(redis_key)
+        CleanUpQueue.run(job_class)
 
         next unless array_of_job_arguments.count.positive?
 
-        store_job_arguments
+        StoreJobArguments.run(job_class, job_tag, array_of_job_arguments)
 
         log_chained_job_start
 
-        parallelism.times { |worked_id| job_class.perform_later(worked_id) }
+        parallelism.times { |worked_id| job_class.perform_later(worked_id, job_tag) }
       end
     end
 
@@ -44,31 +46,15 @@ module ChainedJob
       }
     end
 
-    def store_job_arguments
-      array_of_job_arguments.each_slice(config.arguments_batch_size) do |sublist|
-        redis.rpush(redis_key, sublist)
-      end
-
-      redis.expire(redis_key, config.arguments_queue_expiration)
+    def job_tag
+      @job_tag ||= Time.now.to_f.to_s
     end
 
     def log_chained_job_start
       ChainedJob.logger.info(
-        "#{job_class} starting #{parallelism} workers "\
+        "#{job_class}:#{job_tag} starting #{parallelism} workers "\
         "processing #{array_of_job_arguments.count} items"
       )
-    end
-
-    def redis
-      ChainedJob.redis
-    end
-
-    def redis_key
-      Helpers.redis_key(job_class)
-    end
-
-    def config
-      ChainedJob.config
     end
   end
 end

--- a/lib/chained_job/start_chains.rb
+++ b/lib/chained_job/start_chains.rb
@@ -18,6 +18,7 @@ module ChainedJob
       @parallelism = parallelism
     end
 
+    # rubocop:disable Metrics/AbcSize
     def run
       with_hooks do
         CleanUpQueue.run(job_class)
@@ -31,6 +32,7 @@ module ChainedJob
         parallelism.times { |worked_id| job_class.perform_later(worked_id, job_tag) }
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     private
 

--- a/lib/chained_job/start_chains.rb
+++ b/lib/chained_job/start_chains.rb
@@ -21,11 +21,11 @@ module ChainedJob
     # rubocop:disable Metrics/AbcSize
     def run
       with_hooks do
-        CleanUpQueue.run(job_class)
+        ChainedJob::CleanUpQueue.run(job_class)
 
         next unless array_of_job_arguments.count.positive?
 
-        StoreJobArguments.run(job_class, job_tag, array_of_job_arguments)
+        ChainedJob::StoreJobArguments.run(job_class, job_tag, array_of_job_arguments)
 
         log_chained_job_start
 

--- a/lib/chained_job/store_job_arguments.rb
+++ b/lib/chained_job/store_job_arguments.rb
@@ -17,7 +17,7 @@ module ChainedJob
     end
 
     def run
-      redis.sadd(tag_list, job_tag)
+      update_tag_list
 
       array_of_job_arguments.each_slice(config.arguments_batch_size) do |sublist|
         redis.rpush(redis_key(job_tag), sublist)
@@ -27,6 +27,10 @@ module ChainedJob
     end
 
     private
+
+    def update_tag_list
+      redis.sadd(tag_list, job_tag)
+    end
 
     def tag_list
       Helpers.tag_list(job_key)

--- a/lib/chained_job/store_job_arguments.rb
+++ b/lib/chained_job/store_job_arguments.rb
@@ -17,7 +17,7 @@ module ChainedJob
     end
 
     def run
-      update_tag_list
+      set_tag_list
 
       array_of_job_arguments.each_slice(config.arguments_batch_size) do |sublist|
         redis.rpush(redis_key(job_tag), sublist)
@@ -28,7 +28,7 @@ module ChainedJob
 
     private
 
-    def update_tag_list
+    def set_tag_list
       redis.sadd(tag_list, job_tag)
     end
 

--- a/lib/chained_job/store_job_arguments.rb
+++ b/lib/chained_job/store_job_arguments.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'chained_job/helpers'
+
+module ChainedJob
+  class StoreJobArguments
+    def self.run(job_class, job_tag, array_of_job_arguments)
+      new(job_class, job_tag, array_of_job_arguments).run
+    end
+
+    attr_reader :job_class, :job_tag, :array_of_job_arguments
+
+    def initialize(job_class, job_tag, array_of_job_arguments)
+      @job_class = job_class
+      @job_tag = job_tag
+      @array_of_job_arguments = array_of_job_arguments
+    end
+
+    def run
+      redis.sadd(tag_list, job_tag)
+
+      array_of_job_arguments.each_slice(config.arguments_batch_size) do |sublist|
+        redis.rpush(redis_key(job_tag), sublist)
+      end
+
+      redis.expire(redis_key(job_tag), config.arguments_queue_expiration)
+    end
+
+    private
+
+    def tag_list
+      Helpers.tag_list(job_key)
+    end
+
+    def redis_key(job_tag)
+      @redis_key ||= Helpers.redis_key(job_key, job_tag)
+    end
+
+    def job_key
+      @job_key ||= Helpers.job_key(job_class)
+    end
+
+    def redis
+      ChainedJob.redis
+    end
+
+    def config
+      ChainedJob.config
+    end
+  end
+end

--- a/lib/chained_job/store_job_arguments.rb
+++ b/lib/chained_job/store_job_arguments.rb
@@ -20,10 +20,10 @@ module ChainedJob
       set_tag_list
 
       array_of_job_arguments.each_slice(config.arguments_batch_size) do |sublist|
-        redis.rpush(redis_key(job_tag), sublist)
+        redis.rpush(redis_key, sublist)
       end
 
-      redis.expire(redis_key(job_tag), config.arguments_queue_expiration)
+      redis.expire(redis_key, config.arguments_queue_expiration)
     end
 
     private
@@ -36,7 +36,7 @@ module ChainedJob
       Helpers.tag_list(job_key)
     end
 
-    def redis_key(job_tag)
+    def redis_key
       @redis_key ||= Helpers.redis_key(job_key, job_tag)
     end
 

--- a/lib/chained_job/store_job_arguments.rb
+++ b/lib/chained_job/store_job_arguments.rb
@@ -20,16 +20,16 @@ module ChainedJob
       set_tag_list
 
       array_of_job_arguments.each_slice(config.arguments_batch_size) do |sublist|
-        redis.rpush(redis_key, sublist)
+        ChainedJob.redis.rpush(redis_key, sublist)
       end
 
-      redis.expire(redis_key, config.arguments_queue_expiration)
+      ChainedJob.redis.expire(redis_key, config.arguments_queue_expiration)
     end
 
     private
 
     def set_tag_list
-      redis.sadd(tag_list, job_tag)
+      ChainedJob.redis.sadd(tag_list, job_tag)
     end
 
     def tag_list
@@ -42,10 +42,6 @@ module ChainedJob
 
     def job_key
       @job_key ||= Helpers.job_key(job_class)
-    end
-
-    def redis
-      ChainedJob.redis
     end
 
     def config

--- a/test/chained_job/clean_up_queue_test.rb
+++ b/test/chained_job/clean_up_queue_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+
+class ChainedJob::CleanUpQueueTest < Minitest::Test
+  ARRAY_OF_JOB_ARGUMENTS = %w(1 2 3).freeze
+
+  def test_queue_clean_up
+    assert_equal(redis.lrange(redis_key(job_tag_1), 0, -1), ARRAY_OF_JOB_ARGUMENTS)
+    assert_equal(redis.lrange(redis_key(job_tag_2), 0, -1), ARRAY_OF_JOB_ARGUMENTS)
+
+    tested_class.run(job_class)
+
+    assert_equal(redis.lrange(redis_key(job_tag_1), 0, -1), [])
+    assert_equal(redis.lrange(redis_key(job_tag_2), 0, -1), [])
+  end
+
+  private
+
+  def tested_class
+    ChainedJob::CleanUpQueue
+  end
+
+  def job_class
+    'DummyJob'
+  end
+
+  def redis_key(job_tag)
+    "chained_job:#{job_class}:#{job_tag}"
+  end
+
+  def tag_list
+    "#{job_key}:tags"
+  end
+
+  def job_key
+    "chained_job:#{job_class}"
+  end
+
+  def job_tag_1
+    'Tag_One'
+  end
+
+  def job_tag_2
+    'Tag_Two'
+  end
+
+  def setup
+    ChainedJob.configure do |config|
+      config.redis = redis
+    end
+
+    redis.sadd(tag_list, job_tag_1)
+    redis.sadd(tag_list, job_tag_2)
+    redis.rpush(redis_key(job_tag_1), ARRAY_OF_JOB_ARGUMENTS)
+    redis.rpush(redis_key(job_tag_2), ARRAY_OF_JOB_ARGUMENTS)
+  end
+
+  def redis
+    @redis ||= MockRedis.new
+  end
+
+  def teardown
+    ChainedJob.instance_variable_set(:@config, nil)
+  end
+end

--- a/test/chained_job/clean_up_queue_test.rb
+++ b/test/chained_job/clean_up_queue_test.rb
@@ -5,6 +5,7 @@ require 'minitest/autorun'
 class ChainedJob::CleanUpQueueTest < Minitest::Test
   ARRAY_OF_JOB_ARGUMENTS = %w(1 2 3).freeze
 
+  # rubocop:disable Metrics/AbcSize
   def test_queue_clean_up
     assert_equal(redis.lrange(redis_key(job_tag_1), 0, -1), ARRAY_OF_JOB_ARGUMENTS)
     assert_equal(redis.lrange(redis_key(job_tag_2), 0, -1), ARRAY_OF_JOB_ARGUMENTS)
@@ -14,6 +15,7 @@ class ChainedJob::CleanUpQueueTest < Minitest::Test
     assert_equal(redis.lrange(redis_key(job_tag_1), 0, -1), [])
     assert_equal(redis.lrange(redis_key(job_tag_2), 0, -1), [])
   end
+  # rubocop:enable Metrics/AbcSize
 
   private
 
@@ -46,18 +48,29 @@ class ChainedJob::CleanUpQueueTest < Minitest::Test
   end
 
   def setup
+    setup_redis
+    setup_tag_list
+    setup_arguments_queue
+  end
+
+  def setup_redis
     ChainedJob.configure do |config|
       config.redis = redis
     end
-
-    redis.sadd(tag_list, job_tag_1)
-    redis.sadd(tag_list, job_tag_2)
-    redis.rpush(redis_key(job_tag_1), ARRAY_OF_JOB_ARGUMENTS)
-    redis.rpush(redis_key(job_tag_2), ARRAY_OF_JOB_ARGUMENTS)
   end
 
   def redis
     @redis ||= MockRedis.new
+  end
+
+  def setup_tag_list
+    redis.sadd(tag_list, job_tag_1)
+    redis.sadd(tag_list, job_tag_2)
+  end
+
+  def setup_arguments_queue
+    redis.rpush(redis_key(job_tag_1), ARRAY_OF_JOB_ARGUMENTS)
+    redis.rpush(redis_key(job_tag_2), ARRAY_OF_JOB_ARGUMENTS)
   end
 
   def teardown

--- a/test/chained_job/helpers_test.rb
+++ b/test/chained_job/helpers_test.rb
@@ -5,8 +5,21 @@ require 'minitest/autorun'
 
 class ChainedJob::HelpersTest < Minitest::Test
   def test_redis_key_fetching
+    job_key = 'chained_job:DummyJob'
+    job_tag = '1595252432.198516'
+
+    assert_equal "#{job_key}:#{job_tag}", ChainedJob::Helpers.redis_key(job_key, job_tag)
+  end
+
+  def test_job_key_fetching
     job_class = 'DummyJob'
 
-    assert_equal "chained_job:#{job_class}", ChainedJob::Helpers.redis_key(job_class)
+    assert_equal "chained_job:#{job_class}", ChainedJob::Helpers.job_key(job_class)
+  end
+
+  def test_tag_list_fetching
+    prefix = 'DummyJob'
+
+    assert_equal "#{prefix}:tags", ChainedJob::Helpers.tag_list(prefix)
   end
 end

--- a/test/chained_job/process_test.rb
+++ b/test/chained_job/process_test.rb
@@ -4,15 +4,17 @@ require 'mock_redis'
 require 'minitest/autorun'
 
 class ChainedJob::ProcessTest < Minitest::Test
+  DEFAULT_JOB_TAG = '1595253473.6297688'
+
   # rubocop:disable Metrics/AbcSize
   def test_process_chain
     job_instance.expect(:class, job_class, [])
     job_instance.expect(:class, job_class, [])
     job_instance.expect(:class, job_class, [])
     job_instance.expect(:process, nil, ['1'])
-    job_class.expect(:perform_later, nil, [1])
+    job_class.expect(:perform_later, nil, [1, DEFAULT_JOB_TAG])
 
-    tested_class.run(job_instance, 1)
+    tested_class.run(job_instance, 1, DEFAULT_JOB_TAG)
 
     job_instance.verify
   end
@@ -23,7 +25,7 @@ class ChainedJob::ProcessTest < Minitest::Test
     job_instance.expect(:class, job_class, [])
     job_instance.expect(:class, job_class, [])
     job_instance.expect(:class, job_class, [])
-    tested_class.run(job_instance, 1)
+    tested_class.run(job_instance, 1, DEFAULT_JOB_TAG)
 
     job_instance.verify
   end
@@ -52,7 +54,7 @@ class ChainedJob::ProcessTest < Minitest::Test
   end
 
   def redis_key
-    "chained_job:#{job_class}"
+    "chained_job:#{job_class}:#{DEFAULT_JOB_TAG}"
   end
 
   def job_class

--- a/test/chained_job/start_chains_test.rb
+++ b/test/chained_job/start_chains_test.rb
@@ -7,28 +7,49 @@ class ChainedJob::StartChainsTest < Minitest::Test
   ARRAY_OF_JOB_ARGUMENTS = %w(1 2 3).freeze
 
   def test_start_chains
-    job_class.expect(:perform_later, nil, [0])
-    job_class.expect(:perform_later, nil, [1])
+    job_tag = current_time.to_f.to_s
 
-    tested_class.run(job_class, ARRAY_OF_JOB_ARGUMENTS, 2)
+    with_frozen_time(current_time) do
+      job_class.expect(:perform_later, nil, [0, job_tag])
+      job_class.expect(:perform_later, nil, [1, job_tag])
 
-    job_class.verify
+      tested_class.run(job_class, ARRAY_OF_JOB_ARGUMENTS, 2)
+
+      job_class.verify
+    end
   end
 
   def test_redis_store
-    job_class.expect(:perform_later, nil, [0])
+    job_tag = current_time.to_f.to_s
 
-    tested_class.run(job_class, ARRAY_OF_JOB_ARGUMENTS, 1)
+    with_frozen_time(current_time) do
+      job_class.expect(:perform_later, nil, [0, job_tag])
 
-    assert_equal redis.lrange("chained_job:#{job_class}", 0, -1), ARRAY_OF_JOB_ARGUMENTS
-    job_class.verify
+      tested_class.run(job_class, ARRAY_OF_JOB_ARGUMENTS, 1)
+
+      assert_equal(
+        redis.lrange("chained_job:#{job_class}:#{job_tag}", 0, -1), ARRAY_OF_JOB_ARGUMENTS
+      )
+
+      job_class.verify
+    end
   end
 
   def test_empty_array_of_job_arguments
-    tested_class.run(job_class, [], 1)
+    with_frozen_time(current_time) do
+      tested_class.run(job_class, [], 1)
+    end
   end
 
   private
+
+  def with_frozen_time(time)
+    Time.stub(:now, time) { yield }
+  end
+
+  def current_time
+    @current_time ||= Time.now
+  end
 
   def setup
     ChainedJob.configure do |config|

--- a/test/chained_job/start_chains_test.rb
+++ b/test/chained_job/start_chains_test.rb
@@ -19,22 +19,6 @@ class ChainedJob::StartChainsTest < Minitest::Test
     end
   end
 
-  def test_redis_store
-    job_tag = current_time.to_f.to_s
-
-    with_frozen_time(current_time) do
-      job_class.expect(:perform_later, nil, [0, job_tag])
-
-      tested_class.run(job_class, ARRAY_OF_JOB_ARGUMENTS, 1)
-
-      assert_equal(
-        redis.lrange("chained_job:#{job_class}:#{job_tag}", 0, -1), ARRAY_OF_JOB_ARGUMENTS
-      )
-
-      job_class.verify
-    end
-  end
-
   def test_empty_array_of_job_arguments
     with_frozen_time(current_time) do
       tested_class.run(job_class, [], 1)
@@ -53,7 +37,7 @@ class ChainedJob::StartChainsTest < Minitest::Test
 
   def setup
     ChainedJob.configure do |config|
-      config.redis = redis
+      config.redis = MockRedis.new
     end
   end
 
@@ -63,10 +47,6 @@ class ChainedJob::StartChainsTest < Minitest::Test
 
   def job_class
     @job_class ||= MiniTest::Mock.new
-  end
-
-  def redis
-    @redis ||= MockRedis.new
   end
 
   def tested_class

--- a/test/chained_job/store_job_arguments_test.rb
+++ b/test/chained_job/store_job_arguments_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+
+class ChainedJob::StoreJobArgumentsTest < Minitest::Test
+  ARRAY_OF_JOB_ARGUMENTS = %w(1 2 3).freeze
+
+  def test_redis_store
+    tested_class.run(job_class, job_tag, ARRAY_OF_JOB_ARGUMENTS)
+
+    assert_equal(redis.lrange(redis_key, 0, -1), ARRAY_OF_JOB_ARGUMENTS)
+  end
+
+  def test_set_tag_list
+    tag_list = "chained_job:#{job_class}:tags"
+
+    tested_class.run(job_class, job_tag, ARRAY_OF_JOB_ARGUMENTS)
+
+    assert_equal(redis.spop(tag_list), job_tag)
+  end
+
+  def test_key_expiration
+    tested_class.run(job_class, job_tag, ARRAY_OF_JOB_ARGUMENTS)
+
+    assert_equal(redis.ttl(redis_key), ChainedJob.config.arguments_queue_expiration)
+  end
+
+  private
+
+  def tested_class
+    ChainedJob::StoreJobArguments
+  end
+
+  def job_class
+    'DummyJob'
+  end
+
+  def job_tag
+    current_time.to_f.to_s
+  end
+
+  def redis_key
+    "chained_job:#{job_class}:#{job_tag}"
+  end
+
+  def current_time
+    @current_time ||= Time.now
+  end
+
+  def setup
+    ChainedJob.configure do |config|
+      config.redis = redis
+    end
+  end
+
+  def redis
+    @redis ||= MockRedis.new
+  end
+
+  def teardown
+    ChainedJob.instance_variable_set(:@config, nil)
+  end
+end


### PR DESCRIPTION
Main chained job functionallity difference between `svc-payments` `svc-shipping`  `cs-tool` and `core` that core supports jobs overlapping.

Therefor PR was merged some time ago: https://github.com/vinted/core/pull/27774

Basically each chained job(and its workers) would get its tag(timestamp) and if new job would start before old finishes it would clean the queue - old jobs workers would finish their job since with their tag list would be empty.

@laurynas what do you think about such approach? ~Haven't done any testing so far, want to get early review if this is okeyish(easy to understand what logic goes there) to proceed further with ~manual testing~ (tested in svc-payments, jobs are being executed) and writing tests.~