### PR TITLE
Allow to setup job queue in config

### DIFF
--- a/lib/chained_job/config.rb
+++ b/lib/chained_job/config.rb
@@ -15,6 +15,7 @@ module ChainedJob
       :debug,
       :logger,
       :redis,
+      :queue,
     )
 
     def initialize

--- a/lib/chained_job/middleware.rb
+++ b/lib/chained_job/middleware.rb
@@ -5,6 +5,10 @@ require 'chained_job/process'
 
 module ChainedJob
   module Middleware
+    def self.included(base)
+      base.queue_as ChainedJob.config.queue
+    end
+
     def perform(worker_id = nil)
       if worker_id
         ChainedJob::Process.run(self, worker_id)

--- a/lib/chained_job/middleware.rb
+++ b/lib/chained_job/middleware.rb
@@ -6,7 +6,7 @@ require 'chained_job/process'
 module ChainedJob
   module Middleware
     def self.included(base)
-      base.queue_as ChainedJob.config.queue
+      base.queue_as ChainedJob.config.queue if ChainedJob.config.queue
     end
 
     def perform(worker_id = nil)


### PR DESCRIPTION
This would allow to define sidekiq queue to use for chained jobs:

```ruby
ChainedJob.configure do |config|
  config.queue = :default
end
```
gives:
<img width="1153" alt="Screenshot 2020-07-21 at 10 33 14" src="https://user-images.githubusercontent.com/45848524/88025884-adf24200-cb3d-11ea-8244-cf57dc701c6e.png">
```ruby
ChainedJob.configure do |config|
  config.queue = :default1
end
```
gives:
<img width="1330" alt="Screenshot 2020-07-21 at 10 34 18" src="https://user-images.githubusercontent.com/45848524/88025997-d37f4b80-cb3d-11ea-8869-ea63f1feefed.png">

Do not want to give default value, I think it is better to setup it with configuration

@laurynas 