### PR TITLE
Job arguments support

### DIFF
--- a/lib/chained_job/middleware.rb
+++ b/lib/chained_job/middleware.rb
@@ -10,7 +10,7 @@ module ChainedJob
     end
 
     def perform(worker_id = nil, tag = nil)
-      if worker_id
+      if worker_id.is_a? Numeric
         ChainedJob::Process.run(self, worker_id, tag)
       else
         ChainedJob::StartChains.run(self.class, array_of_job_arguments, parallelism)

--- a/lib/chained_job/version.rb
+++ b/lib/chained_job/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ChainedJob
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
Jobs can have arguments. E.g.

```
update_trackers:
  cron: "* * * * *"
  class: Trackers::BatchUpdateJob
  description: Update active trackers
  args:
    argname: "value"
```

I'm really looking forward to using it. But it conflicts with the current chained job implementation.

It doesn't work due to "perform" method which checks if "worker_id" is defined and acts differently. ActiveJob passes arguments to the same variable. And "worker_id" becomes an object {"argname"=>"value"} rendering this method incalid.

This pull request is a nasty type check that solves the issue for this specific case. What would be the right way to solve it to enable arguments in chained jobs? 


@vinted/backend 


