### PR TITLE
Add around_array_of_job_arguments hook

### DIFF
--- a/lib/chained_job/config.rb
+++ b/lib/chained_job/config.rb
@@ -12,6 +12,7 @@ module ChainedJob
       :arguments_queue_expiration,
       :around_start_chains,
       :around_chain_process,
+      :around_array_of_job_arguments,
       :debug,
       :logger,
       :redis,
@@ -26,6 +27,7 @@ module ChainedJob
 
       self.around_start_chains = ->(_options, &block) { block.call }
       self.around_chain_process = ->(_options, &block) { block.call }
+      self.around_array_of_job_arguments = ->(_options, &block) { block.call }
 
       self.debug = true
     end

--- a/lib/chained_job/middleware.rb
+++ b/lib/chained_job/middleware.rb
@@ -31,4 +31,3 @@ module ChainedJob
     end
   end
 end
-

--- a/lib/chained_job/middleware.rb
+++ b/lib/chained_job/middleware.rb
@@ -13,8 +13,13 @@ module ChainedJob
       if worker_id
         ChainedJob::Process.run(self, worker_id, tag)
       else
-        ChainedJob::StartChains.run(self.class, array_of_job_arguments, parallelism)
+        ChainedJob::StartChains.run(self.class, arguments_array, parallelism)
       end
+    end
+
+    def arguments_array
+      options = { job_class: self.class }
+      ChainedJob.config.around_array_of_job_arguments.call(options) { array_of_job_arguments }
     end
 
     def array_of_job_arguments
@@ -26,3 +31,4 @@ module ChainedJob
     end
   end
 end
+


### PR DESCRIPTION
Want to add hook for availability to track timing of arguments collecting.

@vinted/payments-backend 