### PR TITLE
Feature/document retry failure process

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ class CheckUsersActivityJob < ActiveJob::Base
 end
 ```
 
+### On Failure (Retry queue)
+In the case if one your chained worker fails to process - it will go into retry queue and restarts.
+However important to note, that args picked from Redis, are no longer available, and hence will not be processed.
+
 ## Development
 
 For running tests use `bundle exec rake test`.

--- a/README.md
+++ b/README.md
@@ -117,9 +117,8 @@ class CheckUsersActivityJob < ActiveJob::Base
 end
 ```
 
-### On Failure (Retry queue)
-In the case if one your chained worker fails to process - it will go into retry queue and restarts.
-However important to note, that args picked from Redis, are no longer available, and hence will not be processed.
+### On Failure (retry queue)
+In this case, if one of your chained workers fails to process some ids - it will go into the retry queue and restarts as you would expect. However important to note that args picked from Redis are no longer available, and hence those ids won't be processed anymore.
 
 ## Development
 


### PR DESCRIPTION
Investigating how Chained Workers behave on errors. Found that args no longer present in Redis and will be skipped in case of the error. Maybe not the best way to deal but right now ok. 

In order to save future time for other devs to understand how it works - I drop down explained in the docs. Maybe it's worth adding. 

@mantaskujalis