### PR TITLE
Feature/allow to retry failed args

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,21 @@ end
 ### On Failure (retry queue)
 In this case, if one of your chained workers fails to process some ids - it will go into the retry queue and restarts as you would expect. However important to note that args picked from Redis are no longer available, and hence those ids won't be processed anymore.
 
+In case you want that during exception your arguments would be pushed back to Redis, you can use
+
+```ruby
+
+# frozen_string_literal: true
+
+class CheckUsersActivityJob < ActiveJob::Base
+  include ChainedJob::Middleware
+
+  def handle_retry
+    true
+  end
+end
+```
+
 ## Development
 
 For running tests use `bundle exec rake test`.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ In case you want that during exception your arguments would be pushed back to Re
 class CheckUsersActivityJob < ActiveJob::Base
   include ChainedJob::Middleware
 
-  def handle_retry
+  def handle_retry?
     true
   end
 end

--- a/lib/chained_job/helpers.rb
+++ b/lib/chained_job/helpers.rb
@@ -15,5 +15,9 @@ module ChainedJob
     def tag_list(prefix)
       "#{prefix}:tags"
     end
+
+    def serialize(arguments)
+      arguments.map { |argument| Marshal.dump(argument) }
+    end
   end
 end

--- a/lib/chained_job/process.rb
+++ b/lib/chained_job/process.rb
@@ -35,7 +35,7 @@ module ChainedJob
     private
 
     def handle_retry?
-      job_instance.methods.include?('handle_retry') && job_instance.handle_retry
+      job_instance.methods.include?('handle_retry?') && job_instance.handle_retry?
     end
 
     def with_hooks

--- a/lib/chained_job/process.rb
+++ b/lib/chained_job/process.rb
@@ -19,36 +19,23 @@ module ChainedJob
     end
 
     def run
-      handle_retry ? process_with_retry : process
-    end
-
-    private
-
-    def handle_retry
-      job_instance.respond_to?(:handle_retry) && job_instance.handle_retry
-    end
-
-    def process
-      with_hooks do
-        return finished_worker unless argument
-
-        job_instance.process(argument)
-        job_instance.class.perform_later(args, worker_id, job_tag)
-      end
-    end
-
-    def process_with_retry
       with_hooks do
         return finished_worker unless argument
 
         begin
           job_instance.process(argument)
         rescue StandardError => e
-          repush_job_arguments_back
+          push_job_arguments_back if handle_retry?
           raise e
         end
         job_instance.class.perform_later(args, worker_id, job_tag)
       end
+    end
+
+    private
+
+    def handle_retry?
+      job_instance.respond_to?(:handle_retry) && job_instance.handle_retry
     end
 
     def with_hooks
@@ -95,7 +82,7 @@ module ChainedJob
       Helpers.job_key(job_arguments_key)
     end
 
-    def repush_job_arguments_back
+    def push_job_arguments_back
       ChainedJob.redis.rpush(redis_key, Helpers.serialize([argument]))
     end
   end

--- a/lib/chained_job/process.rb
+++ b/lib/chained_job/process.rb
@@ -35,7 +35,7 @@ module ChainedJob
     private
 
     def handle_retry?
-      job_instance.methods.include?('handle_retry?') && job_instance.handle_retry?
+      job_instance.try(:handle_retry?)
     end
 
     def with_hooks

--- a/lib/chained_job/process.rb
+++ b/lib/chained_job/process.rb
@@ -35,7 +35,7 @@ module ChainedJob
     private
 
     def handle_retry?
-      job_instance.respond_to?(:handle_retry) && job_instance.handle_retry
+      job_instance.methods.include?('handle_retry') && job_instance.handle_retry
     end
 
     def with_hooks

--- a/lib/chained_job/store_job_arguments.rb
+++ b/lib/chained_job/store_job_arguments.rb
@@ -20,7 +20,7 @@ module ChainedJob
       set_tag_list
 
       array_of_job_arguments.each_slice(config.arguments_batch_size) do |sublist|
-        ChainedJob.redis.rpush(redis_key, serialize(sublist))
+        ChainedJob.redis.rpush(redis_key, Helpers.serialize(sublist))
       end
 
       ChainedJob.redis.expire(redis_key, config.arguments_queue_expiration)
@@ -42,10 +42,6 @@ module ChainedJob
 
     def job_key
       @job_key ||= Helpers.job_key(job_arguments_key)
-    end
-
-    def serialize(arguments)
-      arguments.map { |argument| Marshal.dump(argument) }
     end
 
     def config

--- a/lib/chained_job/version.rb
+++ b/lib/chained_job/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ChainedJob
-  VERSION = '0.6.2'
+  VERSION = '0.7.0'
 end

--- a/lib/chained_job/version.rb
+++ b/lib/chained_job/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ChainedJob
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end

--- a/test/chained_job/process_test.rb
+++ b/test/chained_job/process_test.rb
@@ -43,8 +43,8 @@ class ChainedJob::ProcessTest < Minitest::Test
       raise(RuntimeError, 'Service temporary timeout error')
     end
 
-    job_instance.expect(:methods, ['handle_retry'])
-    job_instance.expect(:handle_retry, true)
+    job_instance.expect(:methods, ['handle_retry?'])
+    job_instance.expect(:handle_retry?, true)
 
     assert_raises RuntimeError do
       tested_class.run({}, job_instance, job_instance.class, 1, DEFAULT_JOB_TAG)
@@ -69,8 +69,8 @@ class ChainedJob::ProcessTest < Minitest::Test
       raise(RuntimeError, 'Service temporary timeout error')
     end
 
-    job_instance.expect(:methods, ['handle_retry'])
-    job_instance.expect(:handle_retry, true)
+    job_instance.expect(:methods, ['handle_retry?'])
+    job_instance.expect(:handle_retry?, true)
 
     assert_raises RuntimeError do
       tested_class.run({}, job_instance, job_instance.class, 1, DEFAULT_JOB_TAG)
@@ -95,8 +95,8 @@ class ChainedJob::ProcessTest < Minitest::Test
       raise(RuntimeError, 'Service temporary timeout error')
     end
 
-    job_instance.expect(:methods, ['handle_retry'])
-    job_instance.expect(:handle_retry, true)
+    job_instance.expect(:methods, ['handle_retry?'])
+    job_instance.expect(:handle_retry?, true)
 
     assert_raises RuntimeError do
       tested_class.run({}, job_instance, job_instance.class, 1, DEFAULT_JOB_TAG)

--- a/test/chained_job/process_test.rb
+++ b/test/chained_job/process_test.rb
@@ -43,8 +43,7 @@ class ChainedJob::ProcessTest < Minitest::Test
       raise(RuntimeError, 'Service temporary timeout error')
     end
 
-    job_instance.expect(:methods, ['handle_retry?'])
-    job_instance.expect(:handle_retry?, true)
+    job_instance.expect(:try, true, [:handle_retry?])
 
     assert_raises RuntimeError do
       tested_class.run({}, job_instance, job_instance.class, 1, DEFAULT_JOB_TAG)
@@ -69,8 +68,7 @@ class ChainedJob::ProcessTest < Minitest::Test
       raise(RuntimeError, 'Service temporary timeout error')
     end
 
-    job_instance.expect(:methods, ['handle_retry?'])
-    job_instance.expect(:handle_retry?, true)
+    job_instance.expect(:try, true, [:handle_retry?])
 
     assert_raises RuntimeError do
       tested_class.run({}, job_instance, job_instance.class, 1, DEFAULT_JOB_TAG)
@@ -95,8 +93,7 @@ class ChainedJob::ProcessTest < Minitest::Test
       raise(RuntimeError, 'Service temporary timeout error')
     end
 
-    job_instance.expect(:methods, ['handle_retry?'])
-    job_instance.expect(:handle_retry?, true)
+    job_instance.expect(:try, true, [:handle_retry?])
 
     assert_raises RuntimeError do
       tested_class.run({}, job_instance, job_instance.class, 1, DEFAULT_JOB_TAG)


### PR DESCRIPTION
This change allows us to set workers that we want to try to retry for failed ids. 

Currently, if the worker fails with some ids, the ids newer returned back to the chain and basically newer processed again. Basically, those ids are just gone! However - the exceptions could be for any reason, even soft exceptions, like network, CPU load which went service to timeout, or just the service might not respond just right now - but with the retry - it might still process them. 

## Update 2021-07-26 (to read less)
- [x] Wrote test to cover cases [10], [101, 102], [[1, 2], [3, 4]]
- [x] Explained why we use "why is it wrapped into array?" 
- [x] Release plan
- [x] Bump version

Guys, think about this. This is even worse - for every your deployment, every sidekiq restart, you basically losing args. Some workers might be ok - handles it, but not every worker. Nor every developer knows and expects how actually chained worker handles situations of sidekiq restarts, retry & exception. 

### Release plan
The change is backward compatible. If you want - you use this feature, if not - you just don't use it. It will be written into docs with an explanation of what to expect and how actually it works and in case you want to handle args use handle_retry => true.

- [x] Release into core latest bump version before this change (0.6.1). The core currently uses chained_job (0.5.1)
- [x] Test for a week that core runs fine
- [ ] Release backward compatible with this change (0.6.2) into the core.  
 
## Update 2021-07-26 (ends)
  

### Examples:

#### Without change:

Let's take a look into this worker
```
class PotenciallyFailingJob < ApplicationJob
  include ChainedJob::Middleware

  queue_as :fail

  BATCH_SIZE = 2

  def parallelism
    2
  end

  def handle_retry
    true
  end

  def process(ids)
    ids.each do |id|
      raise "Cannot process bad id #{id} for whatever reasons" if bad_ids.include?(id)

      puts "Processing #{id} completed"
    end
  end

  def array_of_job_arguments
    (bad_ids + good_ids).each_slice(BATCH_SIZE).to_a
  end

  private

  def bad_ids
    [1, 2, 3, 4]
  end

  def good_ids
    [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
  end
end

$bundle exec sidekiq -q fail

```

In this worker, the argument list has bad ids and good ids. The bad ids might not be as hard bad, but processing those could happen like network failure, or the service is unavailable and could be processed later. 

Now without the change, the bad_ids will be pop from Redis, start processing, receives an error, the job goes to retry queue, restarts, and continues with good ids till the end. However, bad_ids are gone and newer retried. 

### With change:

We set into worker handle_retry => true, and while we process bad_ids, receiving an error, we handle the error that bad_ids are push back to the Redis argument list into the back of the argument queue.  This way we continue to process good ids and everything is done, we retry to process bad_ids (depending on your sidekiq retry settings, e.g. 10 times). 


