### PR TITLE
Add Shutdown exception for rescue

### DIFF
--- a/lib/chained_job/process.rb
+++ b/lib/chained_job/process.rb
@@ -21,10 +21,9 @@ module ChainedJob
     def run
       with_hooks do
         return finished_worker unless argument
-
         begin
           job_instance.process(argument)
-        rescue StandardError => e
+        rescue StandardError, Sidekiq::Shutdown => e
           push_job_arguments_back if handle_retry?
           raise e
         end

--- a/lib/chained_job/process.rb
+++ b/lib/chained_job/process.rb
@@ -21,6 +21,7 @@ module ChainedJob
     def run
       with_hooks do
         return finished_worker unless argument
+
         begin
           job_instance.process(argument)
         rescue StandardError, Sidekiq::Shutdown => e

--- a/test/chained_job/process_test.rb
+++ b/test/chained_job/process_test.rb
@@ -15,6 +15,7 @@ class ChainedJob::ProcessTest < Minitest::Test
     job_instance.expect(:class, job_class, [])
     job_instance.expect(:class, job_class, [])
     job_instance.expect(:process, nil, [1])
+    job_instance.expect(:try, false, [:handle_retry?])
     job_class.expect(:perform_later, nil, [{}, 1, DEFAULT_JOB_TAG])
 
     tested_class.run({}, job_instance, job_instance.class, 1, DEFAULT_JOB_TAG)
@@ -26,6 +27,8 @@ class ChainedJob::ProcessTest < Minitest::Test
     job_instance.expect(:class, job_class, [])
     job_instance.expect(:class, job_class, [])
     job_instance.expect(:class, job_class, [])
+    job_instance.expect(:try, false, [:handle_retry?])
+
     tested_class.run({}, job_instance, job_instance.class, 1, DEFAULT_JOB_TAG)
 
     job_instance.verify
@@ -40,7 +43,7 @@ class ChainedJob::ProcessTest < Minitest::Test
     job_instance.expect(:class, job_class.to_s, [])
 
     job_instance.expect(:process, 100) do
-      raise(RuntimeError, 'Service temporary timeout error')
+      raise('Service temporary timeout error')
     end
 
     job_instance.expect(:try, true, [:handle_retry?])
@@ -65,7 +68,7 @@ class ChainedJob::ProcessTest < Minitest::Test
     job_instance.expect(:class, job_class.to_s, [])
 
     job_instance.expect(:process, 100) do
-      raise(RuntimeError, 'Service temporary timeout error')
+      raise('Service temporary timeout error')
     end
 
     job_instance.expect(:try, true, [:handle_retry?])
@@ -90,7 +93,7 @@ class ChainedJob::ProcessTest < Minitest::Test
     job_instance.expect(:class, job_class.to_s, [])
 
     job_instance.expect(:process, [1, 2]) do
-      raise(RuntimeError, 'Service temporary timeout error')
+      raise('Service temporary timeout error')
     end
 
     job_instance.expect(:try, true, [:handle_retry?])


### PR DESCRIPTION
It's more sounds like [Camus-Abusrdism](https://en.wikipedia.org/wiki/Absurdism) and not really sure if this worth it. Maybe just raise awareness of the potential problem and a different solution could be proposed.

<hr>

Right now we have the potential to lose chained worker arguments in case of sidekiq restarts.

E.g. we have a worker, which runs some long tasks.

```
class PotenciallyRestartedJob < ApplicationJob
  include ChainedJob::Middleware

  queue_as :fail

  BATCH_SIZE = 2

  def parallelism
    2
  end

  # Process as before the change
  def handle_retry?
    puts "Handle retry"
    true
  end

  def process(id)
    # lets sleep, e.g. long runnig task 10% chance
    sleep 50 if rand(0..10) > 9

    puts "id #{id} processed -1"
    Redis.current.rpush('processed_id', id)
  end

  def array_of_job_arguments
    # Clear at the start
    Redis.current.del('processed_id')

    (1..20).to_a # [1, 2, 3...20]
  end
end
```

Start sidekiq with timeout and run the worker from e.g. rails console
```$bundle exec sidekiq -q fail -t 5```

Restart a couple of times of sidekiq by
```
$ps -ef | grep sidekiq
$kill -TERM 15935
```

And in the end, we have missing 4 and 14 ids.
```
Redis.current.lrange('processed_id', 0, -1)
=> ["1", "2", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "15", "16", "17", "18", "19", "20"]
```

Hence, adding into rescue Sidekiq::Shutdown, we can put back the current argument to Redis and process them all.

```
Redis.current.lrange('processed_id', 0, -1)
=> ["1", "2", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "15", "16", "17", "18", "19", "20", "4", "14"]
```