### PR TITLE
Rename platform-backend to backend-technologies

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Ruby upgrades
-.ruby-version @vinted/platform-backend
+.ruby-version @vinted/backend-technologies

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-# Ruby upgrades
-.ruby-version @vinted/backend-technologies
+* @vinted/backend-technologies


### PR DESCRIPTION
Renaming platform-backend to backend-technologies.

@vinted/platform-backend 