### PR TITLE
Add rubocop dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,6 @@ gemspec
 
 group :test do
   gem 'mock_redis'
+  gem 'rubocop'
   gem 'rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,10 +6,20 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
     diff-lcs (1.5.1)
+    json (2.7.6)
+    language_server-protocol (3.17.0.3)
     mock_redis (0.30.0)
       ruby2_keywords
+    parallel (1.26.3)
+    parser (3.3.6.0)
+      ast (~> 2.4.1)
+      racc
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (12.3.3)
+    regexp_parser (2.9.2)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -23,7 +33,21 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
+    rubocop (1.68.0)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rubocop-ast (>= 1.32.2, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.34.0)
+      parser (>= 3.3.1.0)
+    ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    unicode-display_width (2.6.0)
 
 PLATFORMS
   ruby
@@ -34,6 +58,7 @@ DEPENDENCIES
   mock_redis
   rake (~> 12.0)
   rspec
+  rubocop
 
 BUNDLED WITH
    2.2.33


### PR DESCRIPTION
Adding rubocop as build is failing:

```
bundle exec rake build

rake aborted!
NameError: uninitialized constant RSpec
/home/avelicka/workstation/chained_job/Rakefile:6:in `<top (required)>'
/home/avelicka/.rbenv/versions/3.0.4/bin/bundle:23:in `load'
/home/avelicka/.rbenv/versions/3.0.4/bin/bundle:23:in `<main>'
(See full trace by running task with --trace)
```